### PR TITLE
Confidence Interval Estimation by using bootstrapping

### DIFF
--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -11,7 +11,13 @@
 ##' @author G Yu
 plotAvgProf <- function(tagMatrix, xlim,
                         xlab="Genomic Region (5'->3')",
-                        ylab = "Read Count Frequency") {
+                        ylab = "Read Count Frequency",
+                        conf = 0.95) {
+
+    if (!is.null(conf)) {
+        p <- plotAvgProfConf.internal(tagMatrix, conf = conf, xlim = xlim,
+                                        xlab = xlab, ylab = ylab) 
+    }
     p <- plotAvgProf.internal(tagMatrix, xlim=xlim,
                               xlab=xlab, ylab=ylab)
     
@@ -270,4 +276,27 @@ plotAvgProf.internal <- function(tagMatrix,
     p <- p+xlab(xlab)+ylab(ylab)
     p <- p + theme_bw() + theme(legend.title=element_blank())
     return(p)
+}
+
+##' @importFrom plyr ldply
+##' @importFrom ggplot2 ggplot
+##' @importFrom ggplot2 geom_line
+##' @importFrom ggplot2 geom_vline
+##' @importFrom ggplot2 scale_x_continuous
+##' @importFrom ggplot2 scale_color_manual
+##' @importFrom ggplot2 xlab
+##' @importFrom ggplot2 ylab
+##' @importFrom ggplot2 theme_bw
+##' @importFrom ggplot2 theme
+##' @importFrom ggplot2 element_blank
+##' @importFrom boot boot
+##' @importFrom boot boot.ci
+plotAvgProfConf.internal function(tagMatrix, conf = 0.95, 
+                                  xlim=c(-3000,3000),
+                                  xlab="Genomic Region (5'->3')",
+                                  ylab="Read Count Frequency") {
+
+## prototype: only support one data
+
+
 }

--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -12,14 +12,15 @@
 plotAvgProf <- function(tagMatrix, xlim,
                         xlab="Genomic Region (5'->3')",
                         ylab = "Read Count Frequency",
-                        conf = 0.95) {
+                        conf) {
 
-    if (!is.null(conf)) {
+    if (!(missingArg(conf))) {
         p <- plotAvgProfConf.internal(tagMatrix, conf = conf, xlim = xlim,
                                         xlab = xlab, ylab = ylab) 
+    } else {
+        p <- plotAvgProf.internal(tagMatrix, xlim=xlim,
+                                  xlab=xlab, ylab=ylab)
     }
-    p <- plotAvgProf.internal(tagMatrix, xlim=xlim,
-                              xlab=xlab, ylab=ylab)
     
     return(p)
 }
@@ -282,6 +283,7 @@ plotAvgProf.internal <- function(tagMatrix,
 ##' @importFrom ggplot2 ggplot
 ##' @importFrom ggplot2 geom_line
 ##' @importFrom ggplot2 geom_vline
+##' @importFrom ggplot2 geom_ribbon
 ##' @importFrom ggplot2 scale_x_continuous
 ##' @importFrom ggplot2 scale_color_manual
 ##' @importFrom ggplot2 xlab
@@ -289,14 +291,42 @@ plotAvgProf.internal <- function(tagMatrix,
 ##' @importFrom ggplot2 theme_bw
 ##' @importFrom ggplot2 theme
 ##' @importFrom ggplot2 element_blank
-##' @importFrom boot boot
-##' @importFrom boot boot.ci
-plotAvgProfConf.internal function(tagMatrix, conf = 0.95, 
-                                  xlim=c(-3000,3000),
-                                  xlab="Genomic Region (5'->3')",
-                                  ylab="Read Count Frequency") {
+plotAvgProfConf.internal <-  function(tagMatrix, conf = 0.95, 
+                                  xlim = c(-3000,3000),
+                                  xlab = "Genomic Region (5'->3')",
+                                  ylab = "Read Count Frequency", 
+                                  verbose = TRUE) {     ## prototype: only support one data
 
-## prototype: only support one data
+    if (verbose){
+        cat(">> Running bootstrapping for tag matrix...\t\t",
+            format(Sys.time(), "%Y-%m-%d %X"), "\n")
+    }
+    tagMxCi <- getTagCountCI(tagMatrix, xlim = xlim, conf = conf)
 
+    if (verbose){
+        cat(">> Generating figures...\t\t",
+            format(Sys.time(), "%Y-%m-%d %X"), "\n")
+    } 
+    tagCount <- getTagCount(tagMatrix, xlim = xlim)
+    tagCount$Lower <- tagMxCi["Lower", ]
+    tagCount$Upper <- tagMxCi["Upper", ]
 
+    pos <- value <- Lower <- Upper <- NULL
+    p <- ggplot(tagCount, aes(pos)) 
+    p <- p + geom_line(aes(y = value)) + 
+            geom_ribbon(aes(ymin = Lower, ymax = Upper), alpha = 0.2) 
+    # the below are same as ygc
+    if ( 0 > xlim[1] && 0 < xlim[2] ) {
+        p <- p + geom_vline(xintercept=0,
+                            linetype="longdash")
+        p <- p + scale_x_continuous(breaks=c(xlim[1], floor(xlim[1]/2),
+                                       0,
+                                       floor(xlim[2]/2), xlim[2]),
+                                   labels=c(xlim[1], floor(xlim[1]/2),
+                                       "TSS",
+                                       floor(xlim[2]/2), xlim[2]))
+    }
+    p <- p + xlab(xlab) + ylab(ylab)
+    p <- p + theme_bw() + theme(legend.title = element_blank())
+    return(p)
 }


### PR DESCRIPTION
Relate to Issue #3. 

**Demo**
```
plotAvgProf(tagMatrix, xlim = c(-3000, 3000), conf = 0.95)
```

**Codes Review**

10. Add argument `conf` to the main function `plotAvgProf` to pass the user-defined confidence interval. 
20. Add new function `plotAvgProfConf.internal` in file *plotTagMatrix.R* for generating figures with CI. 
30. Add 3 new functions `getSgn`, `parseBootCiPerc`, `getTagCountCI` in file *utilities.R*. There are the core functions to estimate confidence interval. 

**To-do**
10. Support `tagMatrix` as input with more than one data. Due to figure design issue, I hesitate before making it happen. 
20. Compatible with main function `plotAvgProf2`. Luckily the bootstrapping core is fully finished, so we'll see it shortly :beers: 







