### PR TITLE
[New] Enable multiple data as input when performing CI estimation

### DIFF
--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -9,7 +9,7 @@
 ##' @param conf confidence interval
 ##' @return ggplot object
 ##' @export
-##' @author G Yu
+##' @author G Yu; Y Yan
 plotAvgProf <- function(tagMatrix, xlim,
                         xlab="Genomic Region (5'->3')",
                         ylab = "Read Count Frequency",
@@ -35,6 +35,7 @@ plotAvgProf <- function(tagMatrix, xlim,
 ##' @param downstream downstream position
 ##' @param xlab xlab
 ##' @param ylab ylab
+##' @param conf confidence interval
 ##' @param verbose print message or not
 ##' @return ggplot object
 ##' @export

--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -15,9 +15,12 @@ plotAvgProf <- function(tagMatrix, xlim,
                         ylab = "Read Count Frequency",
                         conf) {
     conf <- ifelse(missingArg(conf), NA, conf)
-
-    p <- plotAvgProf.internal(tagMatrix, conf = conf, xlim = xlim, 
-                            xlab = xlab, ylab = ylab)
+    if (!(missingArg(conf) || is.na(conf))){
+        p <- plotAvgProf.internal(tagMatrix, conf = conf, xlim = xlim, 
+                                xlab = xlab, ylab = ylab)
+    } else {
+        p <- plotAvgProf.internal(tagMatrix, xlim = xlim, xlab = xlab, ylab = ylab) 
+    }
     return(p)
 }
 
@@ -36,11 +39,12 @@ plotAvgProf <- function(tagMatrix, xlim,
 ##' @return ggplot object
 ##' @export
 ##' @author G Yu
-plotAvgProf2 <- function(peak, weightCol=NULL, TxDb=NULL,
-                        upstream=1000, downstream=1000,
-                        xlab="Genomic Region (5'->3')",
-                        ylab="Read Count Frequency",
-                        verbose=TRUE) {
+plotAvgProf2 <- function(peak, weightCol = NULL, TxDb = NULL,
+                        upstream = 1000, downstream = 1000,
+                        xlab = "Genomic Region (5'->3')",
+                        ylab = "Read Count Frequency",
+                        conf, 
+                        verbose = TRUE) {
     
     if (verbose) {
         cat(">> preparing promoter regions...\t",
@@ -65,8 +69,14 @@ plotAvgProf2 <- function(peak, weightCol=NULL, TxDb=NULL,
         cat(">> plotting figure...\t\t\t",
             format(Sys.time(), "%Y-%m-%d %X"), "\n")
     }
-    p <- plotAvgProf.internal(tagMatrix, xlim=c(-upstream, downstream),
+
+    if (!(missingArg(conf) || is.na(conf))){
+        p <- plotAvgProf.internal(tagMatrix, xlim = c(-upstream, downstream),
+                               xlab = xlab, ylab = ylab, conf = conf)
+    } else {
+        p <- plotAvgProf.internal(tagMatrix, xlim=c(-upstream, downstream),
                                xlab=xlab, ylab=ylab)
+    }
     return(p)
 }
 

--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -252,14 +252,17 @@ plotAvgProf.internal <- function(tagMatrix, conf,
         tagCount <- lapply(tagMatrix, getTagCount, xlim = xlim, conf = conf)
         tagCount <- ldply(tagCount)
         p <- ggplot(tagCount, aes(pos, group=.id, color=.id))
+        if (!(is.na(conf))) {
+            p <- p + geom_ribbon(aes(ymin = Lower, ymax = Upper, fill = .id), 
+                                linetype = 0, alpha = 0.2)
+        }  
     } else {
         tagCount <- getTagCount(tagMatrix, xlim = xlim, conf = conf)
         p <- ggplot(tagCount, aes(pos))
-    }
-
-    if (!(is.na(conf))) {
-        p <- p + geom_ribbon(aes(ymin = Lower, ymax = Upper, fill = .id), 
-                             linetype = 0, alpha = 0.2)
+        if (!(is.na(conf))) {
+            p <- p + geom_ribbon(aes(ymin = Lower, ymax = Upper), 
+                                 linetype = 0, alpha = 0.2)
+        }
     }
 
     p <- p + geom_line(aes(y = value))

--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -14,15 +14,10 @@ plotAvgProf <- function(tagMatrix, xlim,
                         xlab="Genomic Region (5'->3')",
                         ylab = "Read Count Frequency",
                         conf) {
-
-    if (!(missingArg(conf))) {
-        p <- plotAvgProfConf.internal(tagMatrix, conf = conf, xlim = xlim,
-                                        xlab = xlab, ylab = ylab) 
-    } else {
-        p <- plotAvgProf.internal(tagMatrix, xlim=xlim,
-                                  xlab=xlab, ylab=ylab)
-    }
+    conf <- ifelse(missingArg(conf), NA, conf)
     
+    p <- plotAvgProf.internal(tagMatrix, conf = conf, xlim = xlim, 
+                            xlab = xlab, ylab = ylab)
     return(p)
 }
 
@@ -225,7 +220,7 @@ peakHeatmap.internal <- function(tagMatrix, xlim=NULL, color="red", xlab="", yla
 ##' @importFrom ggplot2 theme_bw
 ##' @importFrom ggplot2 theme
 ##' @importFrom ggplot2 element_blank
-plotAvgProf.internal <- function(tagMatrix,
+plotAvgProf.internal <- function(tagMatrix, conf, 
                                   xlim=c(-3000,3000),
                                   xlab="Genomic Region (5'->3')",
                                   ylab="Read Count Frequency") {
@@ -247,6 +242,8 @@ plotAvgProf.internal <- function(tagMatrix,
             stop("please specify appropreate xcoordinations...")
         }
     }
+
+    conf <- ifelse(missingArg(conf), NA, conf)
 
     pos <- value <- .id <- NULL
     

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -47,7 +47,7 @@ getCols <- function(n) {
 }
 
 
-getTagCount <- function(tagMatrix, xlim) {
+getTagCount <- function(tagMatrix, xlim, conf) {
     ss <- colSums(tagMatrix)
     ss <- ss/sum(ss)
     ## plot(1:length(ss), ss, type="l", xlab=xlab, ylab=ylab)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -46,8 +46,7 @@ getCols <- function(n) {
     colorRampPalette(col3)(n)  
 }
 
-##
-## estimate CI using bootstraping
+##' 
 ##
 getSgn <- function(data, idx){
     d <- data[idx, ]
@@ -62,6 +61,7 @@ parseBootCiPerc <- function(bootCiPerc){
     ciUp <- bootCiPerc[tmp]
     return(c(ciLo, ciUp))
 }
+##' estimate CI using bootstraping
 ##' @importFrom boot boot
 ##' @importFrom boot boot.ci
 getTagCiMatrix <- function(tagMatrix, conf = 0.95){

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -46,17 +46,6 @@ getCols <- function(n) {
     colorRampPalette(col3)(n)  
 }
 
-
-getTagCount <- function(tagMatrix, xlim, conf) {
-    ss <- colSums(tagMatrix)
-    ss <- ss/sum(ss)
-    ## plot(1:length(ss), ss, type="l", xlab=xlab, ylab=ylab)
-    pos <- value <- NULL
-    dd <- data.frame(pos=c(xlim[1]:xlim[2]), value=ss)
-    return(dd)
-}
-
-
 ##
 ## estimate CI using bootstraping
 ##
@@ -75,10 +64,12 @@ parseBootCiPerc <- function(bootCiPerc){
 }
 ##' @importFrom boot boot
 ##' @importFrom boot boot.ci
-getTagCountCI <- function(tagMatrix, xlim, conf = 0.95){
+getTagCiMatrix <- function(tagMatrix, conf = 0.95){
     RESAMPLE_TIME <- 500
     trackLen <- ncol(tagMatrix)
     tagMxBoot <- boot(data = tagMatrix, statistic = getSgn, R = RESAMPLE_TIME)
+    cat(">> Running bootstrapping for tag matrix...\t\t",
+        format(Sys.time(), "%Y-%m-%d %X"), "\n")
     tagMxBootCi <- sapply(seq_len(trackLen), function(i) {
                         bootCiToken <- boot.ci(tagMxBoot, type = "perc", index = i) 
                         ## parse boot.ci results
@@ -86,11 +77,21 @@ getTagCountCI <- function(tagMatrix, xlim, conf = 0.95){
                         }
                     )
     row.names(tagMxBootCi) <- c("Lower", "Upper")
-    # pos <- value <- NULL
-    # dd <- data.frame(pos = c(xlim[1]:xlim[2]), 
-    #                 lw = tagMxBootCi[1, ], up = tagMxBootCi[2, ])
-    # return(dd)
     return(tagMxBootCi)
+}
+
+getTagCount <- function(tagMatrix, xlim, conf) {
+    ss <- colSums(tagMatrix)
+    ss <- ss/sum(ss)
+    ## plot(1:length(ss), ss, type="l", xlab=xlab, ylab=ylab)
+    pos <- value <- NULL
+    dd <- data.frame(pos=c(xlim[1]:xlim[2]), value=ss)
+    if (!(missingArg(conf) || is.na(conf))){
+        tagCiMx <- getTagCiMatrix(tagMatrix, conf = conf)
+        dd$Lower <- tagCiMx["Lower", ]
+        dd$Upper <- tagCiMx["Upper", ]
+    }
+    return(dd)
 }
 
 


### PR DESCRIPTION
Related to Issue #5 . 

**Demo**
```
plotAvgProf(tagMatrixList[c(1, 4)], xlim = c(-3000, 3000), conf = 0.95)
```


*For simple try two samples. The one with longest time-cost is fourth one which roughly takes 50 secs.*

It should work but there are still some problems when running: 
```
plotAvgProf2(files[c(1, 4)], weightCol = "V5", TxDb = txdb, 
             upstream = 3000, downstream = 3000,
             xlab = "Genomic Region (5'->3')",
             ylab = "Read Count Frequency",
             conf = 0.95, 
             verbose = TRUE)
```

**Results**
![plotavgprof_conf0 95](https://cloud.githubusercontent.com/assets/1233372/6883985/5d5cec38-d5a1-11e4-8d4b-3bd5a4a11eec.png)
**Codes Changes Review**

10. Enable `getTagCount` to natively incorporate `conf` parameter
20. Merge `plotAvgProfConf.internal` into `plotAvgProf.internal` thus `plotAvgProf` can natively support multiple intputs
30. Other notes changes, e.g. authors for function, function parameters, etc. 

**To-do**
Fix `plotAvgProf2` function. The developer version of this function is quite different from released one. So leave them later. 
