### PR TITLE
Problem with getBioRegion by ["intron", "exon"]

### DIFF
--- a/R/tagMatrix.R
+++ b/R/tagMatrix.R
@@ -97,7 +97,7 @@ getBioRegion <- function(TxDb=NULL,
         regions <- unlist(intronList)
     }
 
-    start_site <- ifelse(strand(regions) == "+", start(bioRegion), end(bioRegion))
+    start_site <- ifelse(strand(regions) == "+", start(regions), end(regions))
 
     bioRegion <- GRanges(seqnames=seqnames(regions),
                          ranges=IRanges(start_site-upstream, start_site+downstream),


### PR DESCRIPTION
getBioRegion does not work for me when I set by to "exon" or "intron".
Might be a copy & paste problem ?