### PR TITLE
uncomment targetFiles <- NULL

### DIFF
--- a/R/enrichOverlap.R
+++ b/R/enrichOverlap.R
@@ -115,7 +115,7 @@ enrichPeakOverlap <- function(queryPeak, targetPeak, TxDb=NULL, pAdjustMethod="B
     query.gr <- loadPeak(queryPeak)
     if (is(targetPeak[1], "GRanges") || is(targetPeak[[1]], "GRanges")) {
         target.gr <- targetPeak
-        ## targetFiles <- NULL
+        targetFiles <- NULL
     } else {
         targetFiles <- parse_targetPeak_Param(targetPeak)
         target.gr <- lapply(targetFiles, loadPeak)


### PR DESCRIPTION
When using the enrichPeakOverlap function with a list of GRanges objects as targetPeak, I get an error that targetFiles object is not found. Repex:

```{r}
library(ChIPseeker)
library(TxDb.Hsapiens.UCSC.hg38.knownGene)
txdb <- TxDb.Hsapiens.UCSC.hg38.knownGene
library(clusterProfiler)

files <- getSampleFiles()
peak1 <- readPeakFile(files[[1]])
peak2 <- readPeakFile(files[[2]])

enriches <- enrichPeakOverlap(queryPeak = peak1,
                  targetPeak    = list(peak2),
                  TxDb          = txdb,
                  pAdjustMethod = "BH",
                  nShuffle      = 50,
                  chainFile     = NULL,
                  verbose       = FALSE)
```

Gives the error:
```
Error in enrichPeakOverlap(queryPeak = peak1, targetPeak = list(peak2),  : 
  object 'targetFiles' not found
```

The line `targetFiles <- NULL` was commented out for some reason in this commit: 758c7bf510cfe0c93e9e962aeb9a0f8d747aa96c (but not in enrichAnnoOverlap) which means futher down `if (is.null(targetFiles))` fails

I'm using ChIPseeker_1.19.1