### PR TITLE
bug fix #191

### DIFF
--- a/R/tagMatrix.R
+++ b/R/tagMatrix.R
@@ -742,7 +742,7 @@ getTagMatrix.binning.internal <- function(peak,
           read <- read+tagMatrixList[[i]][j,z]
         }
         
-        tagMatrix[[i]][j,nbin] <- read/(length(tagMatrixList[[i]][j,])-cursor)
+        tagMatrix[[i]][j,nbin] <- read/(length(tagMatrixList[[i]][j,])-cursor+1)
       }
       
       if(!ignore_strand){
@@ -880,7 +880,7 @@ getTagMatrix.binning.internal <- function(peak,
             read <- read+tagMatrixList[[i]][[j]][z]
           }
           
-          tagMatrix[[i]][j,nbin] <- read/(length(tagMatrixList[[i]][[j]])-cursor)
+          tagMatrix[[i]][j,nbin] <- read/(length(tagMatrixList[[i]][[j]])-cursor+1)
         }
         
         if(!ignore_strand){
@@ -955,7 +955,7 @@ getTagMatrix.binning.internal <- function(peak,
             read <- read+tagMatrixList[[i]][[j]][z]
           }
           
-          tagMatrix[[i]][j,nbin] <- read/(length(tagMatrixList[[i]][[j]])-cursor)
+          tagMatrix[[i]][j,nbin] <- read/(length(tagMatrixList[[i]][[j]])-cursor+1)
           
         }
         


### PR DESCRIPTION
The reported bugs exist #191.
```
files <- getSampleFiles()
peak <- readPeakFile(files[[4]])
test.range <- GRanges(seqnames = c('chr1','chrX','chr1'),ranges = IRanges(c(815094,139583955,3816546), 
                                                                          width=200,gene_id=c('1','100','1000')))
attr(test.range,'type') <- 'body'
attr(test.range,'label') <- c('TSS','TTS')
attr(test.range,'upstream') <- NULL
attr(test.range,'downstream') <- NULL

test.matrix <- getTagMatrix(peak,windows = test.range,nbin = 20,weightCol = 'V5')
test.matrix
```

The pr fixes them.
```
> test.matrix
       [,1]   [,2]   [,3]   [,4]   [,5]   [,6]   [,7]   [,8]   [,9]  [,10]  [,11]
[1,] 295.76 295.76 295.76 295.76 295.76 295.76 295.76 295.76 295.76 295.76 295.76
[2,]  57.57  57.57  57.57  57.57  57.57  57.57  57.57  57.57  57.57  57.57  57.57
[3,] 918.73 918.73 918.73 918.73 918.73 918.73 918.73 918.73 918.73 918.73 918.73
      [,12]  [,13]  [,14]  [,15]  [,16]  [,17]  [,18]  [,19]  [,20]
[1,] 295.76 295.76 295.76 295.76 295.76 295.76 295.76 295.76 295.76
[2,]  57.57  57.57  57.57  57.57  57.57  57.57  57.57  57.57  57.57
[3,] 918.73 918.73 918.73 918.73 918.73 918.73 918.73 918.73 918.73
attr(,"type")
[1] "body"
attr(,"label")
[1] "TSS" "TTS"
attr(,"is.binning")
[1] TRUE
```