### PR TITLE
shorten compile time

### DIFF
--- a/tests/testthat/test-getTagMatrix.R
+++ b/tests/testthat/test-getTagMatrix.R
@@ -1,202 +1,206 @@
-# library(ChIPseeker)
-# library(TxDb.Hsapiens.UCSC.hg19.knownGene)
+testing <- getOption(".yulab_check_ChIPseeker", default = FALSE)
 
-# context("test getTagMatrix() and related functions")
+if(testing){
+    library(ChIPseeker)
+    library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
-# test_that("getBioRegion function", {
-  
-#   # test three kinds of regions derived from getBioRegion()
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
-  
-#   gene_start <- getBioRegion(TxDb = txdb,
-#                              upstream = 1000,
-#                              downstream = 1000,
-#                              by = 'gene',
-#                              type = "start_site")
-#   expect_is(gene_start,"GRanges")
-  
-#   gene_end <- getBioRegion(TxDb = txdb,
-#                            upstream = 1000,
-#                            downstream = 1000,
-#                            by = 'gene',
-#                            type = "end_site")
-#   expect_is(gene_end,"GRanges")
-  
-#   gene_body <- getBioRegion(TxDb = txdb,
-#                             upstream = 1000,
-#                             downstream = 1000,
-#                             by = 'gene',
-#                             type = "body")
-#   expect_is(gene_body,"GRanges")
-  
-#   })
+    context("test getTagMatrix() and related functions")
 
-# test_that("getPromoters functions",{
+    test_that("getBioRegion function", {
   
-#   # test two kinds of regions derived from getPromoters
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        # test three kinds of regions derived from getBioRegion()
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-#   gene <- getPromoters(TxDb=txdb,
-#                        upstream=1000,
-#                        downstream=1000,
-#                        by = "gene")
+        gene_start <- getBioRegion(TxDb = txdb,
+                                   upstream = 1000,
+                                   downstream = 1000,
+                                   by = 'gene',
+                                   type = "start_site")
+        expect_is(gene_start,"GRanges")
   
-#   transcript <- getPromoters(TxDb=txdb,
-#                              upstream=1000,
-#                              downstream=1000,
-#                              by = "transcript")
+        gene_end <- getBioRegion(TxDb = txdb,
+                                 upstream = 1000,
+                                 downstream = 1000,
+                                 by = 'gene',
+                                 type = "end_site")
+        expect_is(gene_end,"GRanges")
   
-#   expect_is(gene,"GRanges")
-#   expect_is(transcript,"GRanges")
+        gene_body <- getBioRegion(TxDb = txdb,
+                                  upstream = 1000,
+                                  downstream = 1000,
+                                  by = 'gene',
+                                  type = "body")
+        expect_is(gene_body,"GRanges")
   
-# })
+    })
 
-# test_that("makeBioRegionFromGranges function",{
+    test_that("getPromoters functions",{
   
-#   # we consider transcript region as enhancer region
-#   # and make self-made granges object
-#   # they can be the same in the form of granges object
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
-#   enhancer <- transcripts(txdb)[1:5000,]
+        # test two kinds of regions derived from getPromoters
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-#   ## we test three kinds of region, start_site, end_site and body
-#   enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
-#                                             by = "enhancer",
-#                                             type = "body")
+        gene <- getPromoters(TxDb=txdb,
+                             upstream=1000,
+                             downstream=1000,
+                             by = "gene")
+        
+        transcript <- getPromoters(TxDb=txdb,
+                                   upstream=1000,
+                                   downstream=1000,
+                                   by = "transcript")
   
-#   enhancer_start <- makeBioRegionFromGranges(gr = enhancer,
-#                                              by = "enhancer",
-#                                              type = "start_site",
-#                                              upstream = 1000,
-#                                              downstream = 1000)
+        expect_is(gene,"GRanges")
+        expect_is(transcript,"GRanges")
   
-#   enhancer_end <- makeBioRegionFromGranges(gr = enhancer,
-#                                            by = "enhancer",
-#                                            type = "end_site",
-#                                            upstream = 1000,
-#                                            downstream = 1000)
-  
-#   expect_is(enhancer_body,"GRanges")
-#   expect_is(enhancer_start,"GRanges")
-#   expect_is(enhancer_end,"GRanges")
-  
-#   ## test the label
-#   expect_equal(attr(enhancer_body,'label'),c("enhancer_SS","enhancer_TS"))
-#   expect_equal(attr(enhancer_start,'label'),"enhancer_SS")
-#   expect_equal(attr(enhancer_end,'label'),"enhancer_TS")
-  
-# })
+    })
 
-# test_that("getTagMatrix function for single peak file",{
+    test_that("makeBioRegionFromGranges function",{
   
-#   peak <- getSampleFiles()[[4]]
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        # we consider transcript region as enhancer region
+        # and make self-made granges object
+        # they can be the same in the form of granges object
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        enhancer <- transcripts(txdb)[1:5000,]
   
-#   # make the window by getBioRegion()
-#   gene_start <- getBioRegion(TxDb = txdb,
-#                              upstream = 1000,
-#                              downstream = 1000,
-#                              by = 'gene',
-#                              type = "start_site")
+        ## we test three kinds of region, start_site, end_site and body
+        enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
+                                                  by = "enhancer",
+                                                  type = "body")
   
-#   # make the window by makeBioRegionFromGranges()
-#   enhancer <- transcripts(txdb)[1:5000,]
+        enhancer_start <- makeBioRegionFromGranges(gr = enhancer,
+                                                   by = "enhancer",
+                                                   type = "start_site",
+                                                   upstream = 1000,
+                                                   downstream = 1000)
   
-#   enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
-#                                             by = "enhancer",
-#                                             type = "body")
+        enhancer_end <- makeBioRegionFromGranges(gr = enhancer,
+                                                 by = "enhancer",
+                                                 type = "end_site",
+                                                 upstream = 1000,
+                                                 downstream = 1000)
   
-#   # test input window parameter
-#   mt1 <- getTagMatrix(peak = peak,
-#                       windows = gene_start,
-#                       weightCol = "V5")
+        expect_is(enhancer_body,"GRanges")
+        expect_is(enhancer_start,"GRanges")
+        expect_is(enhancer_end,"GRanges")
   
-#   expect_is(mt1, "matrix")
+        ## test the label
+        expect_equal(attr(enhancer_body,'label'),c("enhancer_SS","enhancer_TS"))
+        expect_equal(attr(enhancer_start,'label'),"enhancer_SS")
+        expect_equal(attr(enhancer_end,'label'),"enhancer_TS")
   
-#   # without extending flank
-#   mt2_1 <- getTagMatrix(peak = peak,
-#                         windows = enhancer_body,
-#                         weightCol = "V5",
-#                         nbin = 800)
+    })
+
+    test_that("getTagMatrix function for single peak file",{
   
-#   expect_is(mt2_1, "matrix")
+        peak <- getSampleFiles()[[4]]
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+    
+        # make the window by getBioRegion()
+        gene_start <- getBioRegion(TxDb = txdb,
+                                   upstream = 1000,
+                                   downstream = 1000,
+                                   by = 'gene',
+                                   type = "start_site")
   
-#   # extend flank by rel object
-#   mt2_2 <- getTagMatrix(peak = peak,
-#                         windows = enhancer_body,
-#                         weightCol = "V5",
-#                         upstream = rel(0.2),
-#                         downstream = rel(0.2),
-#                         nbin = 800)
+        # make the window by makeBioRegionFromGranges()
+        enhancer <- transcripts(txdb)[1:5000,]
   
-#   expect_is(mt2_2, "matrix")
+        enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
+                                                  by = "enhancer",
+                                                  type = "body")
   
-#   # extend flank by actual number
-#   mt2_3 <- getTagMatrix(peak = peak,
-#                         windows = enhancer_body,
-#                         weightCol = "V5",
-#                         upstream = 1000,
-#                         downstream = 1000,
-#                         nbin = 800)
+        # test input window parameter
+        mt1 <- getTagMatrix(peak = peak,
+                            windows = gene_start,
+                            weightCol = "V5")
   
-#   expect_is(mt2_3, "matrix")
+        expect_is(mt1, "matrix")
   
-#   # test input without window parameter 
+        # without extending flank
+        mt2_1 <- getTagMatrix(peak = peak,
+                              windows = enhancer_body,
+                              weightCol = "V5",
+                              nbin = 800)
   
-#   # make window through txdb object
-#   mt3 <- getTagMatrix(peak = peak,
-#                       weightCol = "V5",
-#                       TxDb = txdb,
-#                       by = "gene",
-#                       type = "start_site",
-#                       upstream = 3000,
-#                       downstream = 3000)
+        expect_is(mt2_1, "matrix")
   
-#   expect_is(mt3, "matrix")
+        # extend flank by rel object
+        mt2_2 <- getTagMatrix(peak = peak,
+                              windows = enhancer_body,
+                              weightCol = "V5",
+                              upstream = rel(0.2),
+                              downstream = rel(0.2),
+                              nbin = 800)
   
-#   # make window through self-made grange object
-#   mt4 <- getTagMatrix(peak = peak,
-#                       weightCol = "V5",
-#                       TxDb = enhancer,
-#                       by = "gene",
-#                       type = "start_site",
-#                       upstream = 1000,
-#                       downstream = 1000)
+        expect_is(mt2_2, "matrix")
   
-#   expect_is(mt4, "matrix")
+        # extend flank by actual number
+        mt2_3 <- getTagMatrix(peak = peak,
+                                windows = enhancer_body,
+                                weightCol = "V5",
+                                upstream = 1000,
+                                downstream = 1000,
+                                nbin = 800)
   
-#   # without extending flank
-#   mt5_1 <- getTagMatrix(peak = peak,
-#                         weightCol = "V5",
-#                         TxDb = txdb,
-#                         by = "gene",
-#                         type = "body",
-#                         nbin = 800)
+        expect_is(mt2_3, "matrix")
   
-#   expect_is(mt5_1, "matrix")
+        # test input without window parameter 
   
-#   # extend flank by rel object
-#   mt5_2 <- getTagMatrix(peak = peak,
-#                         TxDb = enhancer,
-#                         weightCol = "V5",
-#                         by = "enhancer",
-#                         type = "body",
-#                         upstream = rel(0.2),
-#                         downstream = rel(0.2),
-#                         nbin = 800)
+        # make window through txdb object
+        mt3 <- getTagMatrix(peak = peak,
+                            weightCol = "V5",
+                            TxDb = txdb,
+                            by = "gene",
+                            type = "start_site",
+                            upstream = 3000,
+                            downstream = 3000)
   
-#   expect_is(mt5_2, "matrix")
+        expect_is(mt3, "matrix")
   
-#   # extend flank by actual number
-#   mt5_3 <- getTagMatrix(peak = peak,
-#                         TxDb = txdb,
-#                         weightCol = "V5",
-#                         by = "gene",
-#                         type = "body",
-#                         upstream = 1000,
-#                         downstream = 1000,
-#                         nbin = 800)
+        # make window through self-made grange object
+        mt4 <- getTagMatrix(peak = peak,
+                            weightCol = "V5",
+                            TxDb = enhancer,
+                            by = "gene",
+                            type = "start_site",
+                            upstream = 1000,
+                            downstream = 1000)
   
-#   expect_is(mt5_3, "matrix")
+        expect_is(mt4, "matrix")
   
-# })
+        # without extending flank
+        mt5_1 <- getTagMatrix(peak = peak,
+                              weightCol = "V5",
+                              TxDb = txdb,
+                              by = "gene",
+                              type = "body",
+                              nbin = 800)
+  
+        expect_is(mt5_1, "matrix")
+  
+        # extend flank by rel object
+        mt5_2 <- getTagMatrix(peak = peak,
+                              TxDb = enhancer,
+                              weightCol = "V5",
+                              by = "enhancer",
+                              type = "body",
+                              upstream = rel(0.2),
+                              downstream = rel(0.2),
+                              nbin = 800)
+  
+        expect_is(mt5_2, "matrix")
+  
+        # extend flank by actual number
+        mt5_3 <- getTagMatrix(peak = peak,
+                              TxDb = txdb,
+                              weightCol = "V5",
+                              by = "gene",
+                              type = "body",
+                              upstream = 1000,
+                              downstream = 1000,
+                              nbin = 800)
+  
+        expect_is(mt5_3, "matrix")
+  
+    })
+}

--- a/tests/testthat/test-getTagMatrix.R
+++ b/tests/testthat/test-getTagMatrix.R
@@ -1,202 +1,202 @@
-library(ChIPseeker)
-library(TxDb.Hsapiens.UCSC.hg19.knownGene)
+# library(ChIPseeker)
+# library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
-context("test getTagMatrix() and related functions")
+# context("test getTagMatrix() and related functions")
 
-test_that("getBioRegion function", {
+# test_that("getBioRegion function", {
   
-  # test three kinds of regions derived from getBioRegion()
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   # test three kinds of regions derived from getBioRegion()
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-  gene_start <- getBioRegion(TxDb = txdb,
-                             upstream = 1000,
-                             downstream = 1000,
-                             by = 'gene',
-                             type = "start_site")
-  expect_is(gene_start,"GRanges")
+#   gene_start <- getBioRegion(TxDb = txdb,
+#                              upstream = 1000,
+#                              downstream = 1000,
+#                              by = 'gene',
+#                              type = "start_site")
+#   expect_is(gene_start,"GRanges")
   
-  gene_end <- getBioRegion(TxDb = txdb,
-                           upstream = 1000,
-                           downstream = 1000,
-                           by = 'gene',
-                           type = "end_site")
-  expect_is(gene_end,"GRanges")
+#   gene_end <- getBioRegion(TxDb = txdb,
+#                            upstream = 1000,
+#                            downstream = 1000,
+#                            by = 'gene',
+#                            type = "end_site")
+#   expect_is(gene_end,"GRanges")
   
-  gene_body <- getBioRegion(TxDb = txdb,
-                            upstream = 1000,
-                            downstream = 1000,
-                            by = 'gene',
-                            type = "body")
-  expect_is(gene_body,"GRanges")
+#   gene_body <- getBioRegion(TxDb = txdb,
+#                             upstream = 1000,
+#                             downstream = 1000,
+#                             by = 'gene',
+#                             type = "body")
+#   expect_is(gene_body,"GRanges")
   
-  })
+#   })
 
-test_that("getPromoters functions",{
+# test_that("getPromoters functions",{
   
-  # test two kinds of regions derived from getPromoters
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   # test two kinds of regions derived from getPromoters
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-  gene <- getPromoters(TxDb=txdb,
-                       upstream=1000,
-                       downstream=1000,
-                       by = "gene")
+#   gene <- getPromoters(TxDb=txdb,
+#                        upstream=1000,
+#                        downstream=1000,
+#                        by = "gene")
   
-  transcript <- getPromoters(TxDb=txdb,
-                             upstream=1000,
-                             downstream=1000,
-                             by = "transcript")
+#   transcript <- getPromoters(TxDb=txdb,
+#                              upstream=1000,
+#                              downstream=1000,
+#                              by = "transcript")
   
-  expect_is(gene,"GRanges")
-  expect_is(transcript,"GRanges")
+#   expect_is(gene,"GRanges")
+#   expect_is(transcript,"GRanges")
   
-})
+# })
 
-test_that("makeBioRegionFromGranges function",{
+# test_that("makeBioRegionFromGranges function",{
   
-  # we consider transcript region as enhancer region
-  # and make self-made granges object
-  # they can be the same in the form of granges object
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
-  enhancer <- transcripts(txdb)[1:5000,]
+#   # we consider transcript region as enhancer region
+#   # and make self-made granges object
+#   # they can be the same in the form of granges object
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   enhancer <- transcripts(txdb)[1:5000,]
   
-  ## we test three kinds of region, start_site, end_site and body
-  enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
-                                            by = "enhancer",
-                                            type = "body")
+#   ## we test three kinds of region, start_site, end_site and body
+#   enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
+#                                             by = "enhancer",
+#                                             type = "body")
   
-  enhancer_start <- makeBioRegionFromGranges(gr = enhancer,
-                                             by = "enhancer",
-                                             type = "start_site",
-                                             upstream = 1000,
-                                             downstream = 1000)
+#   enhancer_start <- makeBioRegionFromGranges(gr = enhancer,
+#                                              by = "enhancer",
+#                                              type = "start_site",
+#                                              upstream = 1000,
+#                                              downstream = 1000)
   
-  enhancer_end <- makeBioRegionFromGranges(gr = enhancer,
-                                           by = "enhancer",
-                                           type = "end_site",
-                                           upstream = 1000,
-                                           downstream = 1000)
+#   enhancer_end <- makeBioRegionFromGranges(gr = enhancer,
+#                                            by = "enhancer",
+#                                            type = "end_site",
+#                                            upstream = 1000,
+#                                            downstream = 1000)
   
-  expect_is(enhancer_body,"GRanges")
-  expect_is(enhancer_start,"GRanges")
-  expect_is(enhancer_end,"GRanges")
+#   expect_is(enhancer_body,"GRanges")
+#   expect_is(enhancer_start,"GRanges")
+#   expect_is(enhancer_end,"GRanges")
   
-  ## test the label
-  expect_equal(attr(enhancer_body,'label'),c("enhancer_SS","enhancer_TS"))
-  expect_equal(attr(enhancer_start,'label'),"enhancer_SS")
-  expect_equal(attr(enhancer_end,'label'),"enhancer_TS")
+#   ## test the label
+#   expect_equal(attr(enhancer_body,'label'),c("enhancer_SS","enhancer_TS"))
+#   expect_equal(attr(enhancer_start,'label'),"enhancer_SS")
+#   expect_equal(attr(enhancer_end,'label'),"enhancer_TS")
   
-})
+# })
 
-test_that("getTagMatrix function for single peak file",{
+# test_that("getTagMatrix function for single peak file",{
   
-  peak <- getSampleFiles()[[4]]
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   peak <- getSampleFiles()[[4]]
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-  # make the window by getBioRegion()
-  gene_start <- getBioRegion(TxDb = txdb,
-                             upstream = 1000,
-                             downstream = 1000,
-                             by = 'gene',
-                             type = "start_site")
+#   # make the window by getBioRegion()
+#   gene_start <- getBioRegion(TxDb = txdb,
+#                              upstream = 1000,
+#                              downstream = 1000,
+#                              by = 'gene',
+#                              type = "start_site")
   
-  # make the window by makeBioRegionFromGranges()
-  enhancer <- transcripts(txdb)[1:5000,]
+#   # make the window by makeBioRegionFromGranges()
+#   enhancer <- transcripts(txdb)[1:5000,]
   
-  enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
-                                            by = "enhancer",
-                                            type = "body")
+#   enhancer_body <- makeBioRegionFromGranges(gr = enhancer,
+#                                             by = "enhancer",
+#                                             type = "body")
   
-  # test input window parameter
-  mt1 <- getTagMatrix(peak = peak,
-                      windows = gene_start,
-                      weightCol = "V5")
+#   # test input window parameter
+#   mt1 <- getTagMatrix(peak = peak,
+#                       windows = gene_start,
+#                       weightCol = "V5")
   
-  expect_is(mt1, "matrix")
+#   expect_is(mt1, "matrix")
   
-  # without extending flank
-  mt2_1 <- getTagMatrix(peak = peak,
-                        windows = enhancer_body,
-                        weightCol = "V5",
-                        nbin = 800)
+#   # without extending flank
+#   mt2_1 <- getTagMatrix(peak = peak,
+#                         windows = enhancer_body,
+#                         weightCol = "V5",
+#                         nbin = 800)
   
-  expect_is(mt2_1, "matrix")
+#   expect_is(mt2_1, "matrix")
   
-  # extend flank by rel object
-  mt2_2 <- getTagMatrix(peak = peak,
-                        windows = enhancer_body,
-                        weightCol = "V5",
-                        upstream = rel(0.2),
-                        downstream = rel(0.2),
-                        nbin = 800)
+#   # extend flank by rel object
+#   mt2_2 <- getTagMatrix(peak = peak,
+#                         windows = enhancer_body,
+#                         weightCol = "V5",
+#                         upstream = rel(0.2),
+#                         downstream = rel(0.2),
+#                         nbin = 800)
   
-  expect_is(mt2_2, "matrix")
+#   expect_is(mt2_2, "matrix")
   
-  # extend flank by actual number
-  mt2_3 <- getTagMatrix(peak = peak,
-                        windows = enhancer_body,
-                        weightCol = "V5",
-                        upstream = 1000,
-                        downstream = 1000,
-                        nbin = 800)
+#   # extend flank by actual number
+#   mt2_3 <- getTagMatrix(peak = peak,
+#                         windows = enhancer_body,
+#                         weightCol = "V5",
+#                         upstream = 1000,
+#                         downstream = 1000,
+#                         nbin = 800)
   
-  expect_is(mt2_3, "matrix")
+#   expect_is(mt2_3, "matrix")
   
-  # test input without window parameter 
+#   # test input without window parameter 
   
-  # make window through txdb object
-  mt3 <- getTagMatrix(peak = peak,
-                      weightCol = "V5",
-                      TxDb = txdb,
-                      by = "gene",
-                      type = "start_site",
-                      upstream = 3000,
-                      downstream = 3000)
+#   # make window through txdb object
+#   mt3 <- getTagMatrix(peak = peak,
+#                       weightCol = "V5",
+#                       TxDb = txdb,
+#                       by = "gene",
+#                       type = "start_site",
+#                       upstream = 3000,
+#                       downstream = 3000)
   
-  expect_is(mt3, "matrix")
+#   expect_is(mt3, "matrix")
   
-  # make window through self-made grange object
-  mt4 <- getTagMatrix(peak = peak,
-                      weightCol = "V5",
-                      TxDb = enhancer,
-                      by = "gene",
-                      type = "start_site",
-                      upstream = 1000,
-                      downstream = 1000)
+#   # make window through self-made grange object
+#   mt4 <- getTagMatrix(peak = peak,
+#                       weightCol = "V5",
+#                       TxDb = enhancer,
+#                       by = "gene",
+#                       type = "start_site",
+#                       upstream = 1000,
+#                       downstream = 1000)
   
-  expect_is(mt4, "matrix")
+#   expect_is(mt4, "matrix")
   
-  # without extending flank
-  mt5_1 <- getTagMatrix(peak = peak,
-                        weightCol = "V5",
-                        TxDb = txdb,
-                        by = "gene",
-                        type = "body",
-                        nbin = 800)
+#   # without extending flank
+#   mt5_1 <- getTagMatrix(peak = peak,
+#                         weightCol = "V5",
+#                         TxDb = txdb,
+#                         by = "gene",
+#                         type = "body",
+#                         nbin = 800)
   
-  expect_is(mt5_1, "matrix")
+#   expect_is(mt5_1, "matrix")
   
-  # extend flank by rel object
-  mt5_2 <- getTagMatrix(peak = peak,
-                        TxDb = enhancer,
-                        weightCol = "V5",
-                        by = "enhancer",
-                        type = "body",
-                        upstream = rel(0.2),
-                        downstream = rel(0.2),
-                        nbin = 800)
+#   # extend flank by rel object
+#   mt5_2 <- getTagMatrix(peak = peak,
+#                         TxDb = enhancer,
+#                         weightCol = "V5",
+#                         by = "enhancer",
+#                         type = "body",
+#                         upstream = rel(0.2),
+#                         downstream = rel(0.2),
+#                         nbin = 800)
   
-  expect_is(mt5_2, "matrix")
+#   expect_is(mt5_2, "matrix")
   
-  # extend flank by actual number
-  mt5_3 <- getTagMatrix(peak = peak,
-                        TxDb = txdb,
-                        weightCol = "V5",
-                        by = "gene",
-                        type = "body",
-                        upstream = 1000,
-                        downstream = 1000,
-                        nbin = 800)
+#   # extend flank by actual number
+#   mt5_3 <- getTagMatrix(peak = peak,
+#                         TxDb = txdb,
+#                         weightCol = "V5",
+#                         by = "gene",
+#                         type = "body",
+#                         upstream = 1000,
+#                         downstream = 1000,
+#                         nbin = 800)
   
-  expect_is(mt5_3, "matrix")
+#   expect_is(mt5_3, "matrix")
   
-})
+# })

--- a/tests/testthat/test-plotPeakProf.R
+++ b/tests/testthat/test-plotPeakProf.R
@@ -1,117 +1,117 @@
-library(ChIPseeker)
-library(TxDb.Hsapiens.UCSC.hg19.knownGene)
+# library(ChIPseeker)
+# library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
-context("test plotPeakProf() for a list of windows")
+# context("test plotPeakProf() for a list of windows")
 
-peak <- getSampleFiles()[[4]]
-peak_list <- getSampleFiles()[4:5]
-txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+# peak <- getSampleFiles()[[4]]
+# peak_list <- getSampleFiles()[4:5]
+# txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
 
-## self-made enhancer region in the form of granges object
-enhancer <- transcripts(txdb)[1:5000,]
+# ## self-made enhancer region in the form of granges object
+# enhancer <- transcripts(txdb)[1:5000,]
 
-## self-made non-enhancer region in the form of granges object
-non_enhancer <- unlist(fiveUTRsByTranscript(txdb))[1:5000]
+# ## self-made non-enhancer region in the form of granges object
+# non_enhancer <- unlist(fiveUTRsByTranscript(txdb))[1:5000]
 
-gr <- list(enhancer,non_enhancer)
+# gr <- list(enhancer,non_enhancer)
 
-test_that("input two self-made granges object",{
+# test_that("input two self-made granges object",{
   
-  p <- plotPeakProf(peak = peak,
-                    conf = 0.95,
-                    by = c("enhancer","non-enhancer"),
-                    windows_name = c("enhancer","non-enhancer"),
-                    weightCol = "V5",
-                    type = "start_site",
-                    upstream = 1000,
-                    downstream = 1000,
-                    TxDb = list(enhancer,non_enhancer))
+#   p <- plotPeakProf(peak = peak,
+#                     conf = 0.95,
+#                     by = c("enhancer","non-enhancer"),
+#                     windows_name = c("enhancer","non-enhancer"),
+#                     weightCol = "V5",
+#                     type = "start_site",
+#                     upstream = 1000,
+#                     downstream = 1000,
+#                     TxDb = list(enhancer,non_enhancer))
   
-  expect_is(p,"gg")
+#   expect_is(p,"gg")
   
-})
+# })
 
-test_that("input a list of peaks",{
+# test_that("input a list of peaks",{
   
-  p <- plotPeakProf(peak = peak_list,
-                    TxDb = list(enhancer,non_enhancer),
-                    conf = 0.95,
-                    by = c("enhancer","non-enhancer"),
-                    windows_name = c("enhancer","non-enhancer"),
-                    weightCol = "V5",
-                    type = "start_site",
-                    upstream = 1000,
-                    downstream = 1000)
+#   p <- plotPeakProf(peak = peak_list,
+#                     TxDb = list(enhancer,non_enhancer),
+#                     conf = 0.95,
+#                     by = c("enhancer","non-enhancer"),
+#                     windows_name = c("enhancer","non-enhancer"),
+#                     weightCol = "V5",
+#                     type = "start_site",
+#                     upstream = 1000,
+#                     downstream = 1000)
   
-  expect_is(p,"gg")
-})
-
-
-test_that("input gr and txdb input",{
-  
-  p <- plotPeakProf(peak = peak,
-                    TxDb = list(enhancer,txdb),
-                    conf = 0.95,
-                    by = c("enhancer","gene"),
-                    windows_name = c("enhancer","gene"),
-                    weightCol = "V5",
-                    type = "start_site",
-                    upstream = 1000,
-                    downstream = 1000)
-  
-  expect_is(p,"gg")
-})
+#   expect_is(p,"gg")
+# })
 
 
-test_that("check body region",{
+# test_that("input gr and txdb input",{
   
-  p <- plotPeakProf(peak = peak,
-                    TxDb = list(enhancer,txdb),
-                    conf = 0.95,
-                    by = c("enhancer","gene"),
-                    windows_name = c("enhancer","gene"),
-                    weightCol = "V5",
-                    type = "body",
-                    upstream = 1000,
-                    downstream = 1000,
-                    nbin = 800)
+#   p <- plotPeakProf(peak = peak,
+#                     TxDb = list(enhancer,txdb),
+#                     conf = 0.95,
+#                     by = c("enhancer","gene"),
+#                     windows_name = c("enhancer","gene"),
+#                     weightCol = "V5",
+#                     type = "start_site",
+#                     upstream = 1000,
+#                     downstream = 1000)
   
-  expect_is(p,"gg")
+#   expect_is(p,"gg")
+# })
+
+
+# test_that("check body region",{
   
-  p <- plotPeakProf(peak = peak,
-                    TxDb = list(enhancer,txdb),
-                    conf = 0.95,
-                    by = c("enhancer","gene"),
-                    windows_name = c("enhancer","gene"),
-                    weightCol = "V5",
-                    type = "body",
-                    nbin = 800)
+#   p <- plotPeakProf(peak = peak,
+#                     TxDb = list(enhancer,txdb),
+#                     conf = 0.95,
+#                     by = c("enhancer","gene"),
+#                     windows_name = c("enhancer","gene"),
+#                     weightCol = "V5",
+#                     type = "body",
+#                     upstream = 1000,
+#                     downstream = 1000,
+#                     nbin = 800)
   
-  expect_is(p,"gg")
+#   expect_is(p,"gg")
   
-  p <- plotPeakProf(peak = peak,
-                    TxDb = list(enhancer,txdb),
-                    conf = 0.95,
-                    by = c("enhancer","gene"),
-                    windows_name = c("enhancer","gene"),
-                    weightCol = "V5",
-                    type = "body",
-                    upstream = rel(0.2),
-                    downstream = rel(0.2),
-                    nbin = 800)
+#   p <- plotPeakProf(peak = peak,
+#                     TxDb = list(enhancer,txdb),
+#                     conf = 0.95,
+#                     by = c("enhancer","gene"),
+#                     windows_name = c("enhancer","gene"),
+#                     weightCol = "V5",
+#                     type = "body",
+#                     nbin = 800)
   
-  expect_is(p,"gg")
+#   expect_is(p,"gg")
   
-  p <- plotPeakProf(peak = peak_list,
-                    TxDb = list(enhancer,txdb),
-                    conf = 0.95,
-                    by = c("enhancer","gene"),
-                    windows_name = c("enhancer","gene"),
-                    weightCol = "V5",
-                    type = "body",
-                    upstream = rel(0.2),
-                    downstream = rel(0.2),
-                    nbin = 800)
+#   p <- plotPeakProf(peak = peak,
+#                     TxDb = list(enhancer,txdb),
+#                     conf = 0.95,
+#                     by = c("enhancer","gene"),
+#                     windows_name = c("enhancer","gene"),
+#                     weightCol = "V5",
+#                     type = "body",
+#                     upstream = rel(0.2),
+#                     downstream = rel(0.2),
+#                     nbin = 800)
   
-  expect_is(p,"gg")
-})
+#   expect_is(p,"gg")
+  
+#   p <- plotPeakProf(peak = peak_list,
+#                     TxDb = list(enhancer,txdb),
+#                     conf = 0.95,
+#                     by = c("enhancer","gene"),
+#                     windows_name = c("enhancer","gene"),
+#                     weightCol = "V5",
+#                     type = "body",
+#                     upstream = rel(0.2),
+#                     downstream = rel(0.2),
+#                     nbin = 800)
+  
+#   expect_is(p,"gg")
+# })

--- a/tests/testthat/test-plotPeakProf.R
+++ b/tests/testthat/test-plotPeakProf.R
@@ -1,117 +1,121 @@
-# library(ChIPseeker)
-# library(TxDb.Hsapiens.UCSC.hg19.knownGene)
+testing <- getOption(".yulab_check_ChIPseeker", default = FALSE)
 
-# context("test plotPeakProf() for a list of windows")
+if(testing){
+    library(ChIPseeker)
+    library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
-# peak <- getSampleFiles()[[4]]
-# peak_list <- getSampleFiles()[4:5]
-# txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+    context("test plotPeakProf() for a list of windows")
 
-# ## self-made enhancer region in the form of granges object
-# enhancer <- transcripts(txdb)[1:5000,]
+    peak <- getSampleFiles()[[4]]
+    peak_list <- getSampleFiles()[4:5]
+    txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
 
-# ## self-made non-enhancer region in the form of granges object
-# non_enhancer <- unlist(fiveUTRsByTranscript(txdb))[1:5000]
+    ## self-made enhancer region in the form of granges object
+    enhancer <- transcripts(txdb)[1:5000,]
 
-# gr <- list(enhancer,non_enhancer)
+    ## self-made non-enhancer region in the form of granges object
+    non_enhancer <- unlist(fiveUTRsByTranscript(txdb))[1:5000]
 
-# test_that("input two self-made granges object",{
+    gr <- list(enhancer,non_enhancer)
+
+    test_that("input two self-made granges object",{
   
-#   p <- plotPeakProf(peak = peak,
-#                     conf = 0.95,
-#                     by = c("enhancer","non-enhancer"),
-#                     windows_name = c("enhancer","non-enhancer"),
-#                     weightCol = "V5",
-#                     type = "start_site",
-#                     upstream = 1000,
-#                     downstream = 1000,
-#                     TxDb = list(enhancer,non_enhancer))
+        p <- plotPeakProf(peak = peak,
+                          conf = 0.95,
+                          by = c("enhancer","non-enhancer"),
+                          windows_name = c("enhancer","non-enhancer"),
+                          weightCol = "V5",
+                          type = "start_site",
+                          upstream = 1000,
+                          downstream = 1000,
+                          TxDb = list(enhancer,non_enhancer))
+    
+        expect_is(p,"gg")
   
-#   expect_is(p,"gg")
-  
-# })
+    })
 
-# test_that("input a list of peaks",{
-  
-#   p <- plotPeakProf(peak = peak_list,
-#                     TxDb = list(enhancer,non_enhancer),
-#                     conf = 0.95,
-#                     by = c("enhancer","non-enhancer"),
-#                     windows_name = c("enhancer","non-enhancer"),
-#                     weightCol = "V5",
-#                     type = "start_site",
-#                     upstream = 1000,
-#                     downstream = 1000)
-  
-#   expect_is(p,"gg")
-# })
-
-
-# test_that("input gr and txdb input",{
-  
-#   p <- plotPeakProf(peak = peak,
-#                     TxDb = list(enhancer,txdb),
-#                     conf = 0.95,
-#                     by = c("enhancer","gene"),
-#                     windows_name = c("enhancer","gene"),
-#                     weightCol = "V5",
-#                     type = "start_site",
-#                     upstream = 1000,
-#                     downstream = 1000)
-  
-#   expect_is(p,"gg")
-# })
+    test_that("input a list of peaks",{
+    
+        p <- plotPeakProf(peak = peak_list,
+                          TxDb = list(enhancer,non_enhancer),
+                          conf = 0.95,
+                          by = c("enhancer","non-enhancer"),
+                          windows_name = c("enhancer","non-enhancer"),
+                          weightCol = "V5",
+                          type = "start_site",
+                          upstream = 1000,
+                          downstream = 1000)
+        
+        expect_is(p,"gg")
+    })
 
 
-# test_that("check body region",{
+    test_that("input gr and txdb input",{
   
-#   p <- plotPeakProf(peak = peak,
-#                     TxDb = list(enhancer,txdb),
-#                     conf = 0.95,
-#                     by = c("enhancer","gene"),
-#                     windows_name = c("enhancer","gene"),
-#                     weightCol = "V5",
-#                     type = "body",
-#                     upstream = 1000,
-#                     downstream = 1000,
-#                     nbin = 800)
+        p <- plotPeakProf(peak = peak,
+                          TxDb = list(enhancer,txdb),
+                          conf = 0.95,
+                          by = c("enhancer","gene"),
+                          windows_name = c("enhancer","gene"),
+                          weightCol = "V5",
+                          type = "start_site",
+                          upstream = 1000,
+                          downstream = 1000)
+        
+        expect_is(p,"gg")
+    })
+
+
+    test_that("check body region",{
   
-#   expect_is(p,"gg")
+        p <- plotPeakProf(peak = peak,
+                          TxDb = list(enhancer,txdb),
+                          conf = 0.95,
+                          by = c("enhancer","gene"),
+                          windows_name = c("enhancer","gene"),
+                          weightCol = "V5",
+                          type = "body",
+                          upstream = 1000,
+                          downstream = 1000,
+                          nbin = 800)
+        
+        expect_is(p,"gg")
   
-#   p <- plotPeakProf(peak = peak,
-#                     TxDb = list(enhancer,txdb),
-#                     conf = 0.95,
-#                     by = c("enhancer","gene"),
-#                     windows_name = c("enhancer","gene"),
-#                     weightCol = "V5",
-#                     type = "body",
-#                     nbin = 800)
+        p <- plotPeakProf(peak = peak,
+                          TxDb = list(enhancer,txdb),
+                          conf = 0.95,
+                          by = c("enhancer","gene"),
+                          windows_name = c("enhancer","gene"),
+                          weightCol = "V5",
+                          type = "body",
+                          nbin = 800)
   
-#   expect_is(p,"gg")
+        expect_is(p,"gg")
   
-#   p <- plotPeakProf(peak = peak,
-#                     TxDb = list(enhancer,txdb),
-#                     conf = 0.95,
-#                     by = c("enhancer","gene"),
-#                     windows_name = c("enhancer","gene"),
-#                     weightCol = "V5",
-#                     type = "body",
-#                     upstream = rel(0.2),
-#                     downstream = rel(0.2),
-#                     nbin = 800)
+        p <- plotPeakProf(peak = peak,
+                          TxDb = list(enhancer,txdb),
+                          conf = 0.95,
+                          by = c("enhancer","gene"),
+                          windows_name = c("enhancer","gene"),
+                          weightCol = "V5",
+                          type = "body",
+                          upstream = rel(0.2),
+                          downstream = rel(0.2),
+                          nbin = 800)
+        
+        expect_is(p,"gg")
   
-#   expect_is(p,"gg")
-  
-#   p <- plotPeakProf(peak = peak_list,
-#                     TxDb = list(enhancer,txdb),
-#                     conf = 0.95,
-#                     by = c("enhancer","gene"),
-#                     windows_name = c("enhancer","gene"),
-#                     weightCol = "V5",
-#                     type = "body",
-#                     upstream = rel(0.2),
-#                     downstream = rel(0.2),
-#                     nbin = 800)
-  
-#   expect_is(p,"gg")
-# })
+        p <- plotPeakProf(peak = peak_list,
+                          TxDb = list(enhancer,txdb),
+                          conf = 0.95,
+                          by = c("enhancer","gene"),
+                          windows_name = c("enhancer","gene"),
+                          weightCol = "V5",
+                          type = "body",
+                          upstream = rel(0.2),
+                          downstream = rel(0.2),
+                          nbin = 800)
+        
+        expect_is(p,"gg")
+    })
+}

--- a/tests/testthat/test-plotTagMatrix.R
+++ b/tests/testthat/test-plotTagMatrix.R
@@ -1,137 +1,141 @@
-# library(ChIPseeker)
-# library(TxDb.Hsapiens.UCSC.hg19.knownGene)
+testing <- getOption(".yulab_check_ChIPseeker", default = FALSE)
 
-# context("test plotTagMatrix() and related functions")
+if(testing){
+    library(ChIPseeker)
+    library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
-# test_that("test plotPeakProf2 function use txdb",{
+    context("test plotTagMatrix() and related functions")
+
+    test_that("test plotPeakProf2 function use txdb",{
   
-#   peak <- getSampleFiles()[[4]]
-#   peak_list <- getSampleFiles()[4:5]
+        peak <- getSampleFiles()[[4]]
+        peak_list <- getSampleFiles()[4:5]
+        
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        
+        # test single peak file
+        p1_1 <- plotPeakProf(peak = peak,
+                             upstream = 1000,
+                             downstream = 1000,
+                             by = "gene",
+                             type = "start_site",
+                             TxDb = txdb,
+                             nbin = 800)
   
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        expect_is(p1_1, "gg")
   
-#   # test single peak file
-#   p1_1 <- plotPeakProf(peak = peak,
-#                        upstream = 1000,
-#                        downstream = 1000,
-#                        by = "gene",
-#                        type = "start_site",
-#                        TxDb = txdb,
-#                        nbin = 800)
+        # test a list of peak files
+        p1_2 <- plotPeakProf(peak = peak_list,
+                             upstream = 1000,
+                             downstream = 1000,
+                             by = "gene",
+                             type = "start_site",
+                             TxDb = txdb,
+                             nbin = 800)
   
-#   expect_is(p1_1, "gg")
+        expect_is(p1_2, "gg")
   
-#   # test a list of peak files
-#   p1_2 <- plotPeakProf(peak = peak_list,
-#                        upstream = 1000,
-#                        downstream = 1000,
-#                        by = "gene",
-#                        type = "start_site",
-#                        TxDb = txdb,
-#                        nbin = 800)
+        # test body region
+        # without extension
+        p2_1 <- plotPeakProf(peak = peak_list,
+                             by = "gene",
+                             type = "body",
+                             TxDb = txdb,
+                             nbin = 800)
   
-#   expect_is(p1_2, "gg")
+        expect_is(p2_1, "gg")
   
-#   # test body region
-#   # without extension
-#   p2_1 <- plotPeakProf(peak = peak_list,
-#                        by = "gene",
-#                        type = "body",
-#                        TxDb = txdb,
-#                        nbin = 800)
+        # extend with rel object
+        p2_2 <- plotPeakProf(peak = peak_list,
+                             by = "gene",
+                             type = "body",
+                             TxDb = txdb,
+                             upstream = rel(0.2),
+                             downstream = rel(0.2),
+                             nbin = 800)
   
-#   expect_is(p2_1, "gg")
+        expect_is(p2_2, "gg")
   
-#   # extend with rel object
-#   p2_2 <- plotPeakProf(peak = peak_list,
-#                        by = "gene",
-#                        type = "body",
-#                        TxDb = txdb,
-#                        upstream = rel(0.2),
-#                        downstream = rel(0.2),
-#                        nbin = 800)
+        # extend with actual number
+        p2_3 <- plotPeakProf(peak = peak_list,
+                             by = "gene",
+                             type = "body",
+                             TxDb = txdb,
+                             upstream = 1000,
+                             downstream = 1000,
+                             nbin = 800)
+        
+        expect_is(p2_3, "gg")
   
-#   expect_is(p2_2, "gg")
-  
-#   # extend with actual number
-#   p2_3 <- plotPeakProf(peak = peak_list,
-#                        by = "gene",
-#                        type = "body",
-#                        TxDb = txdb,
-#                        upstream = 1000,
-#                        downstream = 1000,
-#                        nbin = 800)
-  
-#   expect_is(p2_3, "gg")
-  
-# })
+    })
 
 
-# test_that("test plotPeakProf2 function use self-made granges",{
+    test_that("test plotPeakProf2 function use self-made granges",{
   
-#   peak <- getSampleFiles()[[4]]
-#   peak_list <- getSampleFiles()[4:5]
+        peak <- getSampleFiles()[[4]]
+        peak_list <- getSampleFiles()[4:5]
+        
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        
+        # we consider transcript region as enhancer region
+        # and make self-made granges object
+        # they can be the same in the form of granges object
+        txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        enhancer <- transcripts(txdb)[1:5000,]
   
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+        # test single peak file
+        p1_1 <- plotPeakProf(peak = peak,
+                             upstream = 1000,
+                             downstream = 1000,
+                             by = "gene",
+                             type = "start_site",
+                             TxDb = enhancer,
+                             nbin = 800)
   
-#   # we consider transcript region as enhancer region
-#   # and make self-made granges object
-#   # they can be the same in the form of granges object
-#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
-#   enhancer <- transcripts(txdb)[1:5000,]
+        expect_is(p1_1, "gg")
   
-#   # test single peak file
-#   p1_1 <- plotPeakProf(peak = peak,
-#                        upstream = 1000,
-#                        downstream = 1000,
-#                        by = "gene",
-#                        type = "start_site",
-#                        TxDb = enhancer,
-#                        nbin = 800)
+        # test a list of peak files
+        p1_2 <- plotPeakProf(peak = peak_list,
+                             upstream = 1000,
+                             downstream = 1000,
+                             by = "gene",
+                             type = "start_site",
+                             TxDb = enhancer,
+                             nbin = 800)
   
-#   expect_is(p1_1, "gg")
+         expect_is(p1_2, "gg")
   
-#   # test a list of peak files
-#   p1_2 <- plotPeakProf(peak = peak_list,
-#                        upstream = 1000,
-#                        downstream = 1000,
-#                        by = "gene",
-#                        type = "start_site",
-#                        TxDb = enhancer,
-#                        nbin = 800)
+        # test body region
+        # without extension
+        p2_1 <- plotPeakProf(peak = peak_list,
+                             by = "gene",
+                             type = "body",
+                             TxDb = enhancer,
+                             nbin = 800)
   
-#   expect_is(p1_2, "gg")
+        expect_is(p2_1, "gg")
   
-#   # test body region
-#   # without extension
-#   p2_1 <- plotPeakProf(peak = peak_list,
-#                        by = "gene",
-#                        type = "body",
-#                        TxDb = enhancer,
-#                        nbin = 800)
+        # extend with rel object
+        p2_2 <- plotPeakProf(peak = peak_list,
+                             by = "gene",
+                             type = "body",
+                             TxDb = enhancer,
+                             upstream = rel(0.2),
+                             downstream = rel(0.2),
+                             nbin = 800)
   
-#   expect_is(p2_1, "gg")
+        expect_is(p2_2, "gg")
   
-#   # extend with rel object
-#   p2_2 <- plotPeakProf(peak = peak_list,
-#                        by = "gene",
-#                        type = "body",
-#                        TxDb = enhancer,
-#                        upstream = rel(0.2),
-#                        downstream = rel(0.2),
-#                        nbin = 800)
+        # extend with actual number
+        p2_3 <- plotPeakProf(peak = peak_list,
+                             by = "gene",
+                             type = "body",
+                             TxDb = enhancer,
+                             upstream = 1000,
+                             downstream = 1000,
+                             nbin = 800)
   
-#   expect_is(p2_2, "gg")
+        expect_is(p2_3, "gg")
   
-#   # extend with actual number
-#   p2_3 <- plotPeakProf(peak = peak_list,
-#                        by = "gene",
-#                        type = "body",
-#                        TxDb = enhancer,
-#                        upstream = 1000,
-#                        downstream = 1000,
-#                        nbin = 800)
-  
-#   expect_is(p2_3, "gg")
-  
-# })
+    })
+}

--- a/tests/testthat/test-plotTagMatrix.R
+++ b/tests/testthat/test-plotTagMatrix.R
@@ -1,137 +1,137 @@
-library(ChIPseeker)
-library(TxDb.Hsapiens.UCSC.hg19.knownGene)
+# library(ChIPseeker)
+# library(TxDb.Hsapiens.UCSC.hg19.knownGene)
 
-context("test plotTagMatrix() and related functions")
+# context("test plotTagMatrix() and related functions")
 
-test_that("test plotPeakProf2 function use txdb",{
+# test_that("test plotPeakProf2 function use txdb",{
   
-  peak <- getSampleFiles()[[4]]
-  peak_list <- getSampleFiles()[4:5]
+#   peak <- getSampleFiles()[[4]]
+#   peak_list <- getSampleFiles()[4:5]
   
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-  # test single peak file
-  p1_1 <- plotPeakProf(peak = peak,
-                       upstream = 1000,
-                       downstream = 1000,
-                       by = "gene",
-                       type = "start_site",
-                       TxDb = txdb,
-                       nbin = 800)
+#   # test single peak file
+#   p1_1 <- plotPeakProf(peak = peak,
+#                        upstream = 1000,
+#                        downstream = 1000,
+#                        by = "gene",
+#                        type = "start_site",
+#                        TxDb = txdb,
+#                        nbin = 800)
   
-  expect_is(p1_1, "gg")
+#   expect_is(p1_1, "gg")
   
-  # test a list of peak files
-  p1_2 <- plotPeakProf(peak = peak_list,
-                       upstream = 1000,
-                       downstream = 1000,
-                       by = "gene",
-                       type = "start_site",
-                       TxDb = txdb,
-                       nbin = 800)
+#   # test a list of peak files
+#   p1_2 <- plotPeakProf(peak = peak_list,
+#                        upstream = 1000,
+#                        downstream = 1000,
+#                        by = "gene",
+#                        type = "start_site",
+#                        TxDb = txdb,
+#                        nbin = 800)
   
-  expect_is(p1_2, "gg")
+#   expect_is(p1_2, "gg")
   
-  # test body region
-  # without extension
-  p2_1 <- plotPeakProf(peak = peak_list,
-                       by = "gene",
-                       type = "body",
-                       TxDb = txdb,
-                       nbin = 800)
+#   # test body region
+#   # without extension
+#   p2_1 <- plotPeakProf(peak = peak_list,
+#                        by = "gene",
+#                        type = "body",
+#                        TxDb = txdb,
+#                        nbin = 800)
   
-  expect_is(p2_1, "gg")
+#   expect_is(p2_1, "gg")
   
-  # extend with rel object
-  p2_2 <- plotPeakProf(peak = peak_list,
-                       by = "gene",
-                       type = "body",
-                       TxDb = txdb,
-                       upstream = rel(0.2),
-                       downstream = rel(0.2),
-                       nbin = 800)
+#   # extend with rel object
+#   p2_2 <- plotPeakProf(peak = peak_list,
+#                        by = "gene",
+#                        type = "body",
+#                        TxDb = txdb,
+#                        upstream = rel(0.2),
+#                        downstream = rel(0.2),
+#                        nbin = 800)
   
-  expect_is(p2_2, "gg")
+#   expect_is(p2_2, "gg")
   
-  # extend with actual number
-  p2_3 <- plotPeakProf(peak = peak_list,
-                       by = "gene",
-                       type = "body",
-                       TxDb = txdb,
-                       upstream = 1000,
-                       downstream = 1000,
-                       nbin = 800)
+#   # extend with actual number
+#   p2_3 <- plotPeakProf(peak = peak_list,
+#                        by = "gene",
+#                        type = "body",
+#                        TxDb = txdb,
+#                        upstream = 1000,
+#                        downstream = 1000,
+#                        nbin = 800)
   
-  expect_is(p2_3, "gg")
+#   expect_is(p2_3, "gg")
   
-})
+# })
 
 
-test_that("test plotPeakProf2 function use self-made granges",{
+# test_that("test plotPeakProf2 function use self-made granges",{
   
-  peak <- getSampleFiles()[[4]]
-  peak_list <- getSampleFiles()[4:5]
+#   peak <- getSampleFiles()[[4]]
+#   peak_list <- getSampleFiles()[4:5]
   
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
   
-  # we consider transcript region as enhancer region
-  # and make self-made granges object
-  # they can be the same in the form of granges object
-  txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
-  enhancer <- transcripts(txdb)[1:5000,]
+#   # we consider transcript region as enhancer region
+#   # and make self-made granges object
+#   # they can be the same in the form of granges object
+#   txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
+#   enhancer <- transcripts(txdb)[1:5000,]
   
-  # test single peak file
-  p1_1 <- plotPeakProf(peak = peak,
-                       upstream = 1000,
-                       downstream = 1000,
-                       by = "gene",
-                       type = "start_site",
-                       TxDb = enhancer,
-                       nbin = 800)
+#   # test single peak file
+#   p1_1 <- plotPeakProf(peak = peak,
+#                        upstream = 1000,
+#                        downstream = 1000,
+#                        by = "gene",
+#                        type = "start_site",
+#                        TxDb = enhancer,
+#                        nbin = 800)
   
-  expect_is(p1_1, "gg")
+#   expect_is(p1_1, "gg")
   
-  # test a list of peak files
-  p1_2 <- plotPeakProf(peak = peak_list,
-                       upstream = 1000,
-                       downstream = 1000,
-                       by = "gene",
-                       type = "start_site",
-                       TxDb = enhancer,
-                       nbin = 800)
+#   # test a list of peak files
+#   p1_2 <- plotPeakProf(peak = peak_list,
+#                        upstream = 1000,
+#                        downstream = 1000,
+#                        by = "gene",
+#                        type = "start_site",
+#                        TxDb = enhancer,
+#                        nbin = 800)
   
-  expect_is(p1_2, "gg")
+#   expect_is(p1_2, "gg")
   
-  # test body region
-  # without extension
-  p2_1 <- plotPeakProf(peak = peak_list,
-                       by = "gene",
-                       type = "body",
-                       TxDb = enhancer,
-                       nbin = 800)
+#   # test body region
+#   # without extension
+#   p2_1 <- plotPeakProf(peak = peak_list,
+#                        by = "gene",
+#                        type = "body",
+#                        TxDb = enhancer,
+#                        nbin = 800)
   
-  expect_is(p2_1, "gg")
+#   expect_is(p2_1, "gg")
   
-  # extend with rel object
-  p2_2 <- plotPeakProf(peak = peak_list,
-                       by = "gene",
-                       type = "body",
-                       TxDb = enhancer,
-                       upstream = rel(0.2),
-                       downstream = rel(0.2),
-                       nbin = 800)
+#   # extend with rel object
+#   p2_2 <- plotPeakProf(peak = peak_list,
+#                        by = "gene",
+#                        type = "body",
+#                        TxDb = enhancer,
+#                        upstream = rel(0.2),
+#                        downstream = rel(0.2),
+#                        nbin = 800)
   
-  expect_is(p2_2, "gg")
+#   expect_is(p2_2, "gg")
   
-  # extend with actual number
-  p2_3 <- plotPeakProf(peak = peak_list,
-                       by = "gene",
-                       type = "body",
-                       TxDb = enhancer,
-                       upstream = 1000,
-                       downstream = 1000,
-                       nbin = 800)
+#   # extend with actual number
+#   p2_3 <- plotPeakProf(peak = peak_list,
+#                        by = "gene",
+#                        type = "body",
+#                        TxDb = enhancer,
+#                        upstream = 1000,
+#                        downstream = 1000,
+#                        nbin = 800)
   
-  expect_is(p2_3, "gg")
+#   expect_is(p2_3, "gg")
   
-})
+# })

--- a/vignettes/ChIPseeker.Rmd
+++ b/vignettes/ChIPseeker.Rmd
@@ -91,7 +91,7 @@ After peak calling, we would like to know the peak locations over the whole geno
 covplot(peak, weightCol="V5")
 ```
 
-```{r fig.height=4, fig.width=10}
+```{r eval=FALSE, fig.height=4, fig.width=10}
 covplot(peak, weightCol="V5", chrs=c("chr17", "chr18"), xlim=c(4.5e7, 5e7))
 ```
 
@@ -161,7 +161,7 @@ peakHeatmap_multiple_Sets(peak = files[[4]],
 ```
 
 We also meet the need of ploting heatmap and peak profiling together.
-```{r fig.cap="Combination of heatmap and peak profiling", fig.align="center", fig.height=9, fig.width=6,results='hide'}
+```{r eval=FALSE, fig.cap="Combination of heatmap and peak profiling", fig.align="center", fig.height=9, fig.width=6,results='hide'}
 peak_Profile_Heatmap(peak = files[[4]],
                      upstream = 1000,
                      downstream = 1000,
@@ -172,7 +172,7 @@ peak_Profile_Heatmap(peak = files[[4]],
 ```
 
 Exploring several regions with heatmap and peak profiling is also supported.
-```{r fig.cap="Combination of heatmap and peak profiling over several regions", fig.align="center", fig.height=12, fig.width=6,results='hide'}
+```{r eval=FALSE, fig.cap="Combination of heatmap and peak profiling over several regions", fig.align="center", fig.height=12, fig.width=6,results='hide'}
 txdb1 <- transcripts(TxDb.Hsapiens.UCSC.hg19.knownGene)
 txdb2 <- unlist(fiveUTRsByTranscript(TxDb.Hsapiens.UCSC.hg19.knownGene))[1:10000,]
 
@@ -523,6 +523,7 @@ enrichPeakOverlap(queryPeak     = files[[5]],
                   pAdjustMethod = "BH",
                   nShuffle      = 50,
                   chainFile     = NULL,
+                  mc.cores      = 2, # set mc.cores to pass check()
                   verbose       = FALSE)
 ```
 


### PR DESCRIPTION
Code in test and vignette are annotated to shorten the compile time.
The test code is for development which can be annotated with no side effect.
And some plot code in vignette are for the same type of plot, which have also been annotated.
In my pc, the devtools::check() time is 
```
Time difference of 14.72798 mins
```
Details of check log 
```
r$>  my_check()
══ Documenting ════════════════════════════════════════════════════════════════════════════
ℹ Updating ChIPseeker documentation
ℹ Loading ChIPseeker
ChIPseeker v1.39.0

If you use ChIPseeker in published research, please cite:
Qianwen Wang, Ming Li, Tianzhi Wu, Li Zhan, Lin Li, Meijun Chen, Wenqin Xie, Zijing Xie, Erqiang Hu, Shuangbin Xu, Guangchuang Yu. Exploring epigenomic datasets by ChIPseeker. Current Protocols 2022, 2(10): e585

══ Building ═══════════════════════════════════════════════════════════════════════════════
Setting env vars:
• CFLAGS    : -Wall -pedantic -fdiagnostics-color=always
• CXXFLAGS  : -Wall -pedantic -fdiagnostics-color=always
• CXX11FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX14FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX17FLAGS: -Wall -pedantic -fdiagnostics-color=always
• CXX20FLAGS: -Wall -pedantic -fdiagnostics-color=always
── R CMD build ────────────────────────────────────────────────────────────────────────────
✔  checking for file ‘/Users/mingli/ChIPseeker/DESCRIPTION’ ...
─  preparing ‘ChIPseeker’:
✔  checking DESCRIPTION meta-information ...
─  installing the package to build vignettes
✔  creating vignettes (5m 34s)
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
─  looking to see if a ‘data/datalist’ file should be added
─  building ‘ChIPseeker_1.39.0.tar.gz’ (1.8s)
   
══ Checking ═══════════════════════════════════════════════════════════════════════════════
Setting env vars:
• _R_CHECK_CRAN_INCOMING_REMOTE_               : FALSE
• _R_CHECK_CRAN_INCOMING_                      : FALSE
• _R_CHECK_FORCE_SUGGESTS_                     : FALSE
• _R_CHECK_PACKAGES_USED_IGNORE_UNUSED_IMPORTS_: FALSE
• NOT_CRAN                                     : true
── R CMD check ────────────────────────────────────────────────────────────────────────────
─  using log directory ‘/private/var/folders/87/15j0wd2x1072h_xnx5fgmds40000gn/T/Rtmps1xsQn/file1058d3bb9dc85/ChIPseeker.Rcheck’
─  using R version 4.2.3 (2023-03-15)
─  using platform: x86_64-apple-darwin17.0 (64-bit)
─  using session charset: UTF-8
─  using options ‘--no-manual --as-cran’ (342ms)
✔  checking for file ‘ChIPseeker/DESCRIPTION’
─  checking extension type ... Package
─  this is package ‘ChIPseeker’ version ‘1.39.0’
─  package encoding: UTF-8
✔  checking package namespace information ...
N  checking package dependencies (17.8s)
   Packages suggested but not available for checking:
     'ggimage', 'ggupset', 'ggVennDiagram'
✔  checking if this is a source package
✔  checking if there is a namespace
✔  checking for executable files (687ms)
✔  checking for hidden files and directories
✔  checking for portable file names ...
✔  checking for sufficient/correct file permissions ...
─  checking whether package ‘ChIPseeker’ can be installed ... [26s/27s] OK (27.1s)
N  checking installed package size ...
     installed size is  7.9Mb
     sub-directories of 1Mb or more:
       data   4.5Mb
       doc    1.8Mb
✔  checking package directory ...
✔  checking for future file timestamps (740ms)
✔  checking ‘build’ directory ...
✔  checking DESCRIPTION meta-information ...
✔  checking top-level files ...
✔  checking for left-over files
✔  checking index information ...
✔  checking package subdirectories ...
✔  checking R files for non-ASCII characters ...
✔  checking R files for syntax errors ...
✔  checking whether the package can be loaded (7.9s)
✔  checking whether the package can be loaded with stated dependencies (7.5s)
✔  checking whether the package can be unloaded cleanly (7.4s)
✔  checking whether the namespace can be loaded with stated dependencies (7.4s)
✔  checking whether the namespace can be unloaded cleanly (7.7s)
✔  checking dependencies in R code (7.9s)
✔  checking S3 generic/method consistency (9.2s)
✔  checking replacement functions (7.3s)
✔  checking foreign function calls (8s)
─  checking R code for possible problems ... [37s/37s] OK (37.4s)
✔  checking Rd files (351ms)
✔  checking Rd metadata ...
N  checking Rd line widths ...
   Rd file 'plotAnnoPie-methods.Rd':
     \usage lines wider than 90 characters:
        plotAnnoPie(x,ndigit=2,cex=0.9,col=NA,legend.position="rightside",pie3D=FALSE,radius=0.8,...)
   
   These lines will be truncated in the PDF manual.
N  checking Rd cross-references (9.9s)
   Package unavailable to check Rd xrefs: ‘ggVennDiagram’
✔  checking for missing documentation entries (7.7s)
✔  checking for code/documentation mismatches (22.3s)
✔  checking Rd \usage sections (9.3s)
✔  checking Rd contents ...
✔  checking for unstated dependencies in examples ...
✔  checking contents of ‘data’ directory (4s)
✔  checking data for non-ASCII characters (2.1s)
✔  checking data for ASCII and uncompressed saves ...
✔  checking installed files from ‘inst/doc’ ...
✔  checking files in ‘vignettes’ ...
─  checking examples ... [11s/11s] OK (10.9s)
✔  checking for unstated dependencies in ‘tests’ ...
─  checking tests ...
✔  Running ‘testthat.R’ (9.1s)
✔  checking for unstated dependencies in vignettes ...
✔  checking package vignettes in ‘inst/doc’ ...
─  checking re-building of vignette outputs ... [302s/308s] OK (5m 8.3s)
✔  checking for non-standard things in the check directory
✔  checking for detritus in the temp directory
   
   See
     ‘/private/var/folders/87/15j0wd2x1072h_xnx5fgmds40000gn/T/Rtmps1xsQn/file1058d3bb9dc85/ChIPseeker.Rcheck/00check.log’
   for details.
```