### PR TITLE
better covplot()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChIPseeker
 Type: Package
 Title: ChIPseeker for ChIP peak Annotation, Comparison, and Visualization
-Version: 1.41.4
+Version: 1.41.3
 Authors@R: c( person(given = "Guangchuang", family = "Yu",       email = "guangchuangyu@gmail.com",      role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
               person(given = "Ming",        family = "Li",       email = "limiang929@gmail.com",         role = "ctb"),
               person(given = "Qianwen",        family = "Wang",       email = "treywea@gmail.com",         role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ChIPseeker
 Type: Package
 Title: ChIPseeker for ChIP peak Annotation, Comparison, and Visualization
-Version: 1.41.3
+Version: 1.41.4
 Authors@R: c( person(given = "Guangchuang", family = "Yu",       email = "guangchuangyu@gmail.com",      role  = c("aut", "cre"), comment = c(ORCID = "0000-0002-6485-8781")),
               person(given = "Ming",        family = "Li",       email = "limiang929@gmail.com",         role = "ctb"),
               person(given = "Qianwen",        family = "Wang",       email = "treywea@gmail.com",         role = "ctb"),
@@ -53,7 +53,8 @@ Imports:
     utils,
     aplot,
     yulab.utils (>= 0.1.5),
-    tibble
+    tibble,
+    stringr
 Suggests:
     clusterProfiler,
     ggimage,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,8 +53,7 @@ Imports:
     utils,
     aplot,
     yulab.utils (>= 0.1.5),
-    tibble,
-    stringr
+    tibble
 Suggests:
     clusterProfiler,
     ggimage,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,7 @@
-# ChIPseeker 1.41.4
+# ChIPseeker 1.41.3
 
 + Better `covplot()`. Support universal chromosome names, and keep the default order of multiple peaks when plot a list of `GRanges` object.
 + Robust `generate_colors()`. Edit the logical of decision, and can validate color code automatically.
-
-# ChIPseeker 1.41.3
-
 + Extend dplyr verbs (`filter()`, `mutate()`, `arrange()`, `rename()`) to peak (`GRanges` object or `data.frame`), see #242.
 
 # ChIPseeker 1.41.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# ChIPseeker 1.41.4
+
++ Better `covplot()`. Support universal chromosome names, and keep the default order of multiple peaks when plot a list of `GRanges` object.
++ Robust `generate_colors()`. Edit the logical of decision, and can validate color code automatically.
+
 # ChIPseeker 1.41.3
 
 + Extend dplyr verbs (`filter()`, `mutate()`, `arrange()`, `rename()`) to peak (`GRanges` object or `data.frame`), see #242.

--- a/R/covplot.R
+++ b/R/covplot.R
@@ -157,7 +157,7 @@ getChrCov <- function(peak, weightCol, chrs, xlim, lower=1) {
     return(df2)
 }
 
-# @param ... other args to `str_sort()`
+# a simple `stringr::str_sort(numeric=TRUE)` implementation
 sortChrName <- function(chr.name, decreasing = FALSE) {
     ## universal sort function, support organisms other than human
     chr_part <- sub("^(\\D*)(\\d*)$", "\\1", chr.name)

--- a/R/covplot.R
+++ b/R/covplot.R
@@ -11,7 +11,7 @@
 ##' @param chrs selected chromosomes to plot, all chromosomes by default
 ##' @param xlim ranges to plot, default is whole chromosome
 ##' @param lower lower cutoff of coverage signal
-##' @param fill_color specify the color for the plot. Order matters
+##' @param fill_color specify the color/palette for the plot. Order matters
 ##' @return ggplot2 object
 ##' @import GenomeInfoDb
 ##' @importFrom ggplot2 ggplot
@@ -35,35 +35,20 @@ covplot <- function(peak, weightCol=NULL,
                     chrs  = NULL,
                     xlim  = NULL,
                     lower = 1,
-                    fill_color = NULL) {
-    
-    isList <- FALSE
-    if(is(peak, "GRanges") || length(peak) == 1) {
-        tm <- getChrCov(peak=peak, weightCol=weightCol, chrs, xlim, lower=lower)
-        
-        if(is.null(fill_color)){
-            fill_color = 'black'
-        }else{
-            if(length(fill_color) != 1){
-                stop('pls input fill_color parameter with correct length...')
-            }
-        }
-        
+                    fill_color = "black") {
+    isList <- is.list(peak)
+    if(!isList) {  # Note: don't support data.frame
+        tm <- getChrCov(peak = peak, weightCol = weightCol, chrs = chrs, xlim = xlim, lower = lower)
     } else {
-        isList <- TRUE
-        ltm <- lapply(peak, getChrCov, weightCol=weightCol, chrs=chrs, xlim=xlim, lower=lower)
+        ltm <- lapply(peak, getChrCov, weightCol = weightCol, chrs = chrs, xlim = xlim, lower = lower)
         if (is.null(names(ltm))) {
             nn <- paste0("peak", seq_along(ltm))
-            warning("input is not a named list, set the name automatically to ", paste(nn, collapse=' '))
+            warning("input is not a named list, set the name automatically to ", paste(nn, collapse = ' '))
             names(ltm) <- nn
         }
-        tm <- list_to_dataframe(ltm)
+        tm <- dplyr::bind_rows(ltm, .id = ".id")
         chr.sorted <- sortChrName(as.character(unique(tm$chr)))
         tm$chr <- factor(tm$chr, levels = chr.sorted)
-        
-        if(!is.null(fill_color) && length(fill_color) != length(unique(tm$.id))){
-            stop('pls input fill_color parameter with correct length...')
-        }
     }
     
     chr <- start <- end <- value <- .id <- NULL
@@ -75,14 +60,16 @@ covplot <- function(peak, weightCol=NULL,
         
         ## p <- p + geom_segment(aes(x=start, y=0, xend=end, yend= value))
         if (isList) {
-            
-            p <- p + geom_rect(aes(xmin=start, ymin=0, xmax=end, ymax=value, fill=.id, color=.id)) 
-            if(!is.null(fill_color)){
-                p <- p + scale_fill_manual(values = fill_color) + scale_color_manual(values = fill_color)
+            if (length(fill_color) == length(peak)){
+                cols = fill_color
+            } else {
+                cols = generate_colors(fill_color, n = length(peak))
             }
-            
+            p <- p + geom_rect(aes(xmin = start, ymin = 0, xmax = end, ymax = value, fill = .id, color = .id)) +
+                scale_color_manual(values = cols) +
+                scale_fill_manual(values = cols)
         } else {
-            p <- p + geom_rect(aes(xmin=start, ymin=0, xmax=end, ymax=value), fill=fill_color, color=fill_color)
+            p <- p + geom_rect(aes(xmin = start, ymin = 0, xmax = end, ymax = value), fill = fill_color, color = fill_color)
         }
         
         if(length(unique(tm$chr)) > 1) {
@@ -92,9 +79,10 @@ covplot <- function(peak, weightCol=NULL,
     }
     
     p <- p + theme_classic()
-    p <- p + xlab(xlab) + ylab(ylab) + ggtitle(title)
-    p <- p + scale_y_continuous(expand=c(0,0))
+    p <- p + labs(x = xlab, y = ylab, title = title, fill = NULL, color = NULL)
+    p <- p + scale_y_continuous(expand = c(0,0))
     p <- p + theme(strip.text.y=element_text(angle=360))
+    p <- p + scale_x_continuous(labels = scales::label_number(scale_cut = scales::cut_si("")))
     
     if (!is.null(xlim) && !all(is.na(xlim)) && is.numeric(xlim) && length(xlim) == 2) {
         p <- p + xlim(xlim)
@@ -123,7 +111,7 @@ getChrCov <- function(peak, weightCol, chrs, xlim, lower=1) {
         peak.cov <- coverage(peak.gr, weight=weight)
     }
 
-    cov <- lapply(peak.cov, slice, lower=lower)
+    cov <- lapply(peak.cov, IRanges::slice, lower=lower)
 
     get.runValue <- function(x) {
         y <- runValue(x)
@@ -165,23 +153,12 @@ getChrCov <- function(peak, weightCol, chrs, xlim, lower=1) {
         df <- df[df$start >= xlim[1] & df$end <= xlim[2],]
     }
 
-    df2 <- group_by(df, chr, start, end) %>% summarise(value=sum(cnt))
+    df2 <- group_by(df, chr, start, end) %>% summarise(value=sum(cnt), .groups = "drop")
     return(df2)
 }
 
-sortChrName <- function(chr.name) {
-    ## X, Y and M will cause warnings when change to number.
-    noChr <- suppressWarnings(as.numeric(sub("chr", "", chr.name)))
-    ## index of chromosome name are character, such as X, Y
-    ch.idx <- which(is.na(noChr))
-    
-    n.idx <- which(!is.na(noChr))
-    chr.n <- noChr[n.idx]
-
-    chr.sorted <- chr.name[n.idx][order(chr.n)]
-    if (length(ch.idx) != 0) {
-        chr.sorted <- c(chr.sorted, sort(chr.name[ch.idx]))
-    }
-         
-    return(chr.sorted)
+# @param ... other args to `str_sort()`
+sortChrName <- function(chr.name, decreasing = FALSE, numeric = TRUE, ...) {
+    ## universal sort function, support organisms other than human
+    stringr::str_sort(chr.name, decreasing = decreasing, numeric = numeric, ...)
 }

--- a/R/covplot.R
+++ b/R/covplot.R
@@ -158,7 +158,11 @@ getChrCov <- function(peak, weightCol, chrs, xlim, lower=1) {
 }
 
 # @param ... other args to `str_sort()`
-sortChrName <- function(chr.name, decreasing = FALSE, numeric = TRUE, ...) {
+sortChrName <- function(chr.name, decreasing = FALSE) {
     ## universal sort function, support organisms other than human
-    stringr::str_sort(chr.name, decreasing = decreasing, numeric = numeric, ...)
+    chr_part <- sub("^(\\D*)(\\d*)$", "\\1", chr.name)
+    num_part <- as.numeric(sub("^(\\D*)(\\d*)$", "\\2", chr.name))
+    chr.name[order(chr_part, num_part, decreasing = decreasing)]
 }
+
+

--- a/R/covplot.R
+++ b/R/covplot.R
@@ -60,7 +60,7 @@ covplot <- function(peak, weightCol=NULL,
         
         ## p <- p + geom_segment(aes(x=start, y=0, xend=end, yend= value))
         if (isList) {
-            if (length(fill_color) == length(peak)){
+            if (length(fill_color) == length(peak) && all(is_valid_color(fill_color))){
                 cols = fill_color
             } else {
                 cols = generate_colors(fill_color, n = length(peak))

--- a/R/plotDistToTSS.R
+++ b/R/plotDistToTSS.R
@@ -25,18 +25,22 @@ generate_break_lbs = function(breaks) {
   return(lbs)
 }
 
-generate_colors = function(
-    palette = NULL, 
-    n) {
-  if (length(palette) == 1){
+generate_colors = function(palette = NULL, n) {
+  # old color in version <= 1.41.1
+  old_color = c("#9ecae1", "#3182bd", "#C7A76C", "#86B875", "#39BEB1", "#CD99D8")
+  if (is.null(palette)){
+    brewer_cols = old_color
+  } else if (length(palette) == 1 && is_valid_palette(palette)){
     brewer_cols = RColorBrewer::brewer.pal(
       name = palette, 
       n = RColorBrewer::brewer.pal.info[palette, "maxcolors"]
-    ) |> rev()
-  } else if (length(palette) > 1){
+    ) |> rev()     
+  } else if (all(is_valid_color(palette))){
     brewer_cols = palette
-  } else {
-    brewer_cols = c("#9ecae1", "#3182bd", "#C7A76C", "#86B875", "#39BEB1", "#CD99D8")
+  }
+  else {
+    warning("Your palette is non-valid, switching to default...")
+    brewer_cols = old_color
   }
   
   if (length(brewer_cols) >= n) {
@@ -46,6 +50,19 @@ generate_colors = function(
   }
   
   return(cols)
+}
+
+is_valid_palette = function(palette){
+  palette %in% rownames(RColorBrewer::brewer.pal.info)
+}
+
+is_valid_color = function(color){
+  tryCatch({
+    grDevices::col2rgb(color)
+    TRUE
+  }, error = function(e) {
+    FALSE
+  })
 }
 
 ##' plot feature distribution based on the distances to the TSS

--- a/vignettes/ChIPseeker.Rmd
+++ b/vignettes/ChIPseeker.Rmd
@@ -79,7 +79,6 @@ The datasets _CBX6_ and _CBX7_ in this vignettes were downloaded from _GEO (GSE4
 files <- getSampleFiles()
 print(files)
 peak <- readPeakFile(files[[4]])
-peak
 ```
 
 ## ChIP peaks coverage plot
@@ -93,6 +92,15 @@ covplot(peak, weightCol="V5")
 
 ```{r fig.height=4, fig.width=10}
 covplot(peak, weightCol="V5", chrs=c("chr17", "chr18"), xlim=c(4.5e7, 5e7))
+```
+
+When `peak` is a `GRangsList` object, user can set the needed colors or by passing a palette to `fill_color`.
+
+```{r fig.height=8, fig.width=10}
+peaks = lapply(files[4:5], readPeakFile)
+covplot(peaks, weightCol = "V5", fill_color = c("red","blue")) +
+  theme(legend.position = "inside",
+        legend.position.inside = c(0.8,0.2))
 ```
 
 

--- a/vignettes/ChIPseeker.Rmd
+++ b/vignettes/ChIPseeker.Rmd
@@ -95,7 +95,7 @@ covplot(peak, weightCol="V5")
 covplot(peak, weightCol="V5", chrs=c("chr17", "chr18"), xlim=c(4.5e7, 5e7))
 ```
 
-When `peak` is a `GRangsList` object, user can set the needed colors or by passing a palette to `fill_color`.
+When `peak` is a `GRangsList` object, user can set the colors directly or by passing a palette to `fill_color`.
 
 ```{r fig.height=8, fig.width=10}
 peaks = lapply(files[4:5], readPeakFile)

--- a/vignettes/ChIPseeker.Rmd
+++ b/vignettes/ChIPseeker.Rmd
@@ -79,6 +79,7 @@ The datasets _CBX6_ and _CBX7_ in this vignettes were downloaded from _GEO (GSE4
 files <- getSampleFiles()
 print(files)
 peak <- readPeakFile(files[[4]])
+peak
 ```
 
 ## ChIP peaks coverage plot


### PR DESCRIPTION
+ Better `covplot()`. Support universal chromosome names other than `c("chr1","chr2")`, and keep the default order of multiple peaks when plot a list of `GRanges` object. Labels of x-axis is formatted by default.
+ Robust `generate_colors()`. Edit the logical of decision, and can validate color code automatically.

For example,

```r
files <- getSampleFiles()
peaks = lapply(files[4:5], readPeakFile)
covplot(peaks, weightCol = "V5", fill_color = c("red","blue")) +
  theme(legend.position = "inside",
        legend.position.inside = c(0.8,0.2))
```

![image](https://github.com/user-attachments/assets/3fffc2de-3c5f-4814-9e84-b77feef1ef5c)
