### PR TITLE
Should be a bug 

### DIFF
--- a/R/plotTagMatrix.R
+++ b/R/plotTagMatrix.R
@@ -1950,16 +1950,7 @@ peakHeatmap.internal <- function(tagMatrix,
                                            upstream))
   }else{
     
-    p <- p + scale_x_continuous(breaks = c(1,
-                                           floor(downstream*0.5),
-                                           (downstream + 1),
-                                           (downstream + 1 + floor(upstream * 0.5)), 
-                                           upstream+downstream+1),
-                                labels = c((-1*downstream),
-                                           floor(-1*downstream*0.5),
-                                           0,
-                                           floor(upstream*0.5),
-                                           upstream))    
+    p <- p + scale_x_continuous(labels = function(x) x - upstream)    
     
   }
   


### PR DESCRIPTION
When run the following example

```r
library(ChIPseeker)
library(TxDb.Hsapiens.UCSC.hg19.knownGene)
txdb <- TxDb.Hsapiens.UCSC.hg19.knownGene
promoter <- getPromoters(TxDb=txdb, upstream=3000, downstream=500)
tagMatrix <- getTagMatrix(peak, windows=promoter)
tagHeatmap(tagMatrix)
```

![image](https://github.com/user-attachments/assets/1dfa7104-9b53-449f-b225-1e0796098180)

The x-axis label should be wrong. After fix, it will give

![image](https://github.com/user-attachments/assets/7dafa21d-72c3-403a-8b79-38fe157a97d2)
